### PR TITLE
ci: Require PRs in conventional commits syntax

### DIFF
--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,0 +1,26 @@
+name: "Validate PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # When using "Squash and merge" on a PR with only one commit, GitHub
+          # will suggest using that commit message instead of the PR title for
+          # the merge commit, and it's easy to commit this by mistake. Enable
+          # this option to also validate the commit message for one-commit PRs.
+          validateSingleCommit: true
+          # Opt-in to validate that the PR title matches the single commit to
+          # avoid confusion.
+          validateSingleCommitMatchesPrTitle: true


### PR DESCRIPTION
This will allow automated generation of changelogs and releases based
on PR titles.
