### PR TITLE
ci: Add test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,36 @@
+name: test
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    name: Build and Lint on ${{ matrix.os }}, Node.js ${{ matrix.node-version }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        # Oldest supported LTS version through current LTS
+        node-version: [12.x, 14.x, 16.x]
+        os: [macOS-latest, windows-latest, ubuntu-latest]
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Deps
+        run: npm ci
+      - name: Build Selenium DriverProvider JAR
+        run: npm run jar
+      - name: Test all packages
+        shell: bash
+        run: |
+          npm test
+          for i in backends/*/; do
+            pushd "$i"
+            npm test
+            popd
+          done

--- a/backends/chromecast/package.json
+++ b/backends/chromecast/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "lint": "(cd ../../; npx eslint --ignore-path .gitignore --max-warnings 0 backends/chromecast/)",
     "checkClean": "[[ -z \"$(git status --short .)\" ]] || (echo \"Git not clean!\"; git status .; exit 1)",
-    "pretest": "npm run lint",
+    "test": "npm run lint",
     "prepack": "npm run lint && npm run checkClean"
   },
   "bin": {

--- a/backends/chromeos/package.json
+++ b/backends/chromeos/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "lint": "(cd ../../; npx eslint --ignore-path .gitignore --max-warnings 0 backends/chromeos/)",
     "checkClean": "[[ -z \"$(git status --short .)\" ]] || (echo \"Git not clean!\"; git status .; exit 1)",
-    "pretest": "npm run lint",
+    "test": "npm run lint",
     "prepack": "npm run lint && npm run checkClean"
   },
   "bin": {

--- a/backends/fake/package.json
+++ b/backends/fake/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "lint": "(cd ../../; npx eslint --ignore-path .gitignore --max-warnings 0 backends/fake/)",
     "checkClean": "[[ -z \"$(git status --short .)\" ]] || (echo \"Git not clean!\"; git status .; exit 1)",
-    "pretest": "npm run lint",
+    "test": "npm run lint",
     "prepack": "npm run lint && npm run checkClean"
   },
   "bin": {

--- a/backends/tizen/package.json
+++ b/backends/tizen/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "lint": "(cd ../../; npx eslint --ignore-path .gitignore --max-warnings 0 backends/tizen/)",
     "checkClean": "[[ -z \"$(git status --short .)\" ]] || (echo \"Git not clean!\"; git status .; exit 1)",
-    "pretest": "npm run lint",
+    "test": "npm run lint",
     "prepack": "npm run lint && npm run checkClean"
   },
   "bin": {

--- a/backends/xboxone/package.json
+++ b/backends/xboxone/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "lint": "(cd ../../; npx eslint --ignore-path .gitignore --max-warnings 0 backends/xboxone/)",
     "checkClean": "[[ -z \"$(git status --short .)\" ]] || (echo \"Git not clean!\"; git status .; exit 1)",
-    "pretest": "npm run lint",
+    "test": "npm run lint",
     "prepack": "npm run lint && npm run checkClean"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint --ignore-path .gitignore --max-warnings 0 .",
     "jar": "ant -f java/build.xml jar && cp java/build/jar/*.jar java/third_party/selenium*.jar ./",
     "checkClean": "[[ -z \"$(git status --short .)\" ]] || (echo \"Git not clean!\"; git status .; exit 1)",
-    "pretest": "npm run lint",
+    "test": "npm run lint",
     "prepack": "npm run lint && npm run checkClean && npm run jar"
   },
   "dependencies": {


### PR DESCRIPTION
Although there aren't any real tests (see #31), we can run the linter
on new PRs.  When we add tests later, the workflow will activate them
through npm test.