### PR TITLE
ci: Fix linter errors on Windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    name: Build and Lint on ${{ matrix.os }}, Node.js ${{ matrix.node-version }}
+    name: Build and Test on ${{ matrix.os }}, Node.js ${{ matrix.node-version }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -13,8 +13,11 @@ jobs:
         # Oldest supported LTS version through current LTS
         node-version: [12.x, 14.x, 16.x]
         os: [macOS-latest, windows-latest, ubuntu-latest]
+      fail-fast: false
 
     steps:
+      - name: Configure git
+        run: git config --global core.autocrlf false
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Setup Node.js ${{ matrix.node-version }}
@@ -22,7 +25,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Deps
-        run: npm ci
+        shell: bash
+        run: |
+          npm ci
+          for i in backends/*/; do
+            pushd "$i"
+            npm ci
+            popd
+          done
       - name: Build Selenium DriverProvider JAR
         run: npm run jar
       - name: Test all packages

--- a/backends/chromecast/package.json
+++ b/backends/chromecast/package.json
@@ -19,7 +19,7 @@
   ],
   "main": "chromecast-webdriver-server.js",
   "scripts": {
-    "lint": "(cd ../../; npx eslint --ignore-path .gitignore --max-warnings 0 backends/chromecast/)",
+    "lint": "true # linted at the top level",
     "checkClean": "[[ -z \"$(git status --short .)\" ]] || (echo \"Git not clean!\"; git status .; exit 1)",
     "test": "npm run lint",
     "prepack": "npm run lint && npm run checkClean"

--- a/backends/chromeos/package.json
+++ b/backends/chromeos/package.json
@@ -20,7 +20,7 @@
   ],
   "main": "chromeos-webdriver-server.js",
   "scripts": {
-    "lint": "(cd ../../; npx eslint --ignore-path .gitignore --max-warnings 0 backends/chromeos/)",
+    "lint": "true # linted at the top level",
     "checkClean": "[[ -z \"$(git status --short .)\" ]] || (echo \"Git not clean!\"; git status .; exit 1)",
     "test": "npm run lint",
     "prepack": "npm run lint && npm run checkClean"

--- a/backends/fake/package.json
+++ b/backends/fake/package.json
@@ -18,7 +18,7 @@
   ],
   "main": "fake-webdriver-server.js",
   "scripts": {
-    "lint": "(cd ../../; npx eslint --ignore-path .gitignore --max-warnings 0 backends/fake/)",
+    "lint": "true # linted at the top level",
     "checkClean": "[[ -z \"$(git status --short .)\" ]] || (echo \"Git not clean!\"; git status .; exit 1)",
     "test": "npm run lint",
     "prepack": "npm run lint && npm run checkClean"

--- a/backends/tizen/package.json
+++ b/backends/tizen/package.json
@@ -19,7 +19,7 @@
   ],
   "main": "tizen-webdriver-server.js",
   "scripts": {
-    "lint": "(cd ../../; npx eslint --ignore-path .gitignore --max-warnings 0 backends/tizen/)",
+    "lint": "true # linted at the top level",
     "checkClean": "[[ -z \"$(git status --short .)\" ]] || (echo \"Git not clean!\"; git status .; exit 1)",
     "test": "npm run lint",
     "prepack": "npm run lint && npm run checkClean"

--- a/backends/xboxone/package.json
+++ b/backends/xboxone/package.json
@@ -19,7 +19,7 @@
   ],
   "main": "xbox-one-webdriver-server.js",
   "scripts": {
-    "lint": "(cd ../../; npx eslint --ignore-path .gitignore --max-warnings 0 backends/xboxone/)",
+    "lint": "true # linted at the top level",
     "checkClean": "[[ -z \"$(git status --short .)\" ]] || (echo \"Git not clean!\"; git status .; exit 1)",
     "test": "npm run lint",
     "prepack": "npm run lint && npm run checkClean"


### PR DESCRIPTION
Configure git in the test workflow to check out code with LF line
endings on Windows, so that we pass linter checks.

Fixes #33